### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
    repositories {
 
-       maven { url 'http://repo.springsource.org/plugins-release' }
+       maven { url 'https://repo.springsource.org/plugins-release' }
 
    }
 
@@ -26,12 +26,12 @@ allprojects {
 	
 	repositories {
 		flatDir dirs: ["${gradle.gradleHomeDir}/lib"]
-                maven { url  'http://repo.springsource.org' }
-		maven { url  'http://maven.springframework.org/release' }
-		maven { url  'http://repo.springsource.org/libs-milestone' }
+                maven { url  'https://repo.springsource.org' }
+		maven { url  'https://maven.springframework.org/release' }
+		maven { url  'https://repo.springsource.org/libs-milestone' }
 		maven { url  'http://spring-roo-repository.springsource.org/release' }
 		mavenCentral()
-		maven { url 'http://maven.springframework.org/snapshot' }
+		maven { url 'https://maven.springframework.org/snapshot' }
 	}
 }
 
@@ -97,8 +97,8 @@ subprojects { subproject ->
 		}
 	}
 
-	// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-	// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+	// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+	// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 	configurations { jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 	}
 
@@ -430,7 +430,7 @@ task dist(dependsOn: assemble) {
 task wrapper(type: Wrapper) {
 	description = 'Generates gradlew[.bat] scripts'
 	gradleVersion = '1.0-rc-1-20120409112701+0200'
-	distributionUrl = 'http://services.gradle.org/distributions-snapshots/gradle-1.0-rc-1-20120409112701+0200-bin.zip'
+	distributionUrl = 'https://services.gradle.org/distributions-snapshots/gradle-1.0-rc-1-20120409112701+0200-bin.zip'
 	jarFile = '.wrapper/gradle-wrapper.jar'
 }
 
@@ -476,12 +476,12 @@ def customizePom(def pom, def gradleProject) {
 			url = 'https://github.com/SpringSource/spring-nanotrader'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://springsource.org'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://spring-roo-repository.springsource.org/release (404) could not be migrated:  
   ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://maven.springframework.org/release (ReadTimeoutException) migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result ReadTimeoutException).
* http://maven.springframework.org/snapshot (ReadTimeoutException) migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result ReadTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.springsource.org migrated to:  
  https://repo.springsource.org ([https](https://repo.springsource.org) result 301).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://services.gradle.org/distributions-snapshots/gradle-1.0-rc-1-20120409112701+0200-bin.zip migrated to:  
  https://services.gradle.org/distributions-snapshots/gradle-1.0-rc-1-20120409112701+0200-bin.zip ([https](https://services.gradle.org/distributions-snapshots/gradle-1.0-rc-1-20120409112701+0200-bin.zip) result 301).
* http://springsource.org migrated to:  
  https://springsource.org ([https](https://springsource.org) result 301).
* http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html migrated to:  
  https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html ([https](https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html) result 301).
* http://www.gradle.org/docs/current/userguide/dependency_management.html migrated to:  
  https://www.gradle.org/docs/current/userguide/dependency_management.html ([https](https://www.gradle.org/docs/current/userguide/dependency_management.html) result 301).