### PR TITLE
URL Cleanup

### DIFF
--- a/.wrapper/gradle-wrapper.properties
+++ b/.wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.2-bin.zip

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
 		maven { url  'http://maven.springframework.org/release' }
 		maven { url  'http://repo.springsource.org/libs-milestone' }
 		maven { url  'http://spring-roo-repository.springsource.org/release' }
-		mavenCentral()
+		maven { url 'https://repo.maven.apache.org/maven2/' }
 		maven { url 'http://maven.springframework.org/snapshot' }
 	}
 }
@@ -198,7 +198,7 @@ project('tools') {
 	apply plugin: 'groovy'
 
 	repositories {
-	    mavenCentral()
+	    maven { url 'https://repo.maven.apache.org/maven2/' }
 	}
 
 	configurations {

--- a/tools/.wrapper/gradle-wrapper.properties
+++ b/tools/.wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.2-bin.zip

--- a/tools/selenium/.wrapper/gradle-wrapper.properties
+++ b/tools/selenium/.wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://repo.gradle.org/gradle/distributions-snapshots/gradle-1.0-milestone-8-20120112000036+0100-bin.zip
+distributionUrl=https\://repo.gradle.org/gradle/distributions-snapshots/gradle-1.0-milestone-8-20120112000036+0100-bin.zip

--- a/tools/selenium/build.gradle
+++ b/tools/selenium/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'eclipse'
 
 repositories {
-    mavenCentral()
+    maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 configurations {


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.